### PR TITLE
Patch for removed (Python 3.8+) time.clock function

### DIFF
--- a/alignak_module_webui/module.py
+++ b/alignak_module_webui/module.py
@@ -655,7 +655,10 @@ class WebuiBroker(BaseModule, Daemon):
         logger.debug("manage_brok_thread start ...")
 
         while not self.interrupted:
-            start = time.clock()
+            if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+                start = time.perf_counter()
+            else:
+                start = time.clock()
             # Get messages in the queue
             try:
                 message = self.to_q.get()
@@ -708,8 +711,12 @@ class WebuiBroker(BaseModule, Daemon):
                     self.nb_writers -= 1
                     self.global_lock.release()
 
-            logger.debug("time to manage %d broks (time %.2gs)",
-                         len(message), time.clock() - start)
+            if sys.version_info[0] >= 3 and sys.version_info[1] >= 8:
+                logger.debug("time to manage %d broks (time %.2gs)",
+                            len(message), time.perf_counter() - start)
+            else:
+                logger.debug("time to manage %d broks (time %.2gs)",
+                            len(message), time.clock() - start)
         logger.info("Exiting the manage broks thread...")
 
     def fmwk_thread(self):


### PR DESCRIPTION
Time.clock is deprecated in Python 3.3+ and removed outright in Python 3.8+. [Suggested replacements](https://docs.python.org/3.7/library/time.html#time.clock) are time.perf_counter or time.process_time. Not sure which better aligns with the original intent, since time.clock behaviour was OS dependent.

You probably don't want to merge this pull request as written, since it's a compromise fix that maintains backward compatibility by checking the version at runtime. But since I can't submit "issues" on a forked repository, this seemed like the next best way to raise to your attention!